### PR TITLE
Make helper functions privately-scoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,64 +14,11 @@ $base58->encode('129f5a5c1545dc3a1db567154121878f08f8572cdf45e5549c624fb3f01fbd2
 
 ### Methods
 
-#### `hex_to_bin`
-Convert a hexadecimal string to a binary array
-
-    @param    string  $hex  A hexadecimal string to convert to a binary array
-    @return   array
-
-#### `bin_to_hex`
-Convert a binary array to a hexadecimal string
-
-    @param    array   $bin  A binary array to convert to a hexadecimal string
-    @return   string
-
-#### `str_to_bin`
-Convert a string to a binary array
-
-    @param    string   $str  A string to convert to a binary array
-    @return   array
-
-#### `bin_to_str`
-Convert a binary array to a string
-
-    @param    array   $bin  A binary array to convert to a string
-    @return   string
-
-#### `uint8_be_to_64`
-Convert a UInt8BE (one unsigned big endian byte) array to UInt64
-
-    @param    array   $data  A UInt8BE array to convert to UInt64
-    @return   number
-
-#### `uint64_to_8_be`
-Convert a UInt64 (unsigned 64 bit integer) to a UInt8BE array
-
-    @param    number   $num   A UInt64 number to convert to a UInt8BE array
-    @param    integer  $size  Size of array to return
-    @return   array
-
-#### `encode_block`
-Convert a hexadecimal (Base16) array to a Base58 string
-
-    @param    array   $data
-    @param    array   $buf
-    @param    number  $index 
-    @return   array
-
 #### `encode`
 Encode a hexadecimal (Base16) string to Base58
 
     @param    string  $hex  A hexadecimal (Base16) string to convert to Base58
     @return   string
-
-#### `decode_block`
-Convert a Base58 input to hexadecimal (Base16)
-
-    @param    array    $data
-    @param    array    $buf
-    @param    integer  $index
-    @return   array
 
 #### `decode`
 Decode a Base58 string to hexadecimal (Base16)

--- a/base58.php
+++ b/base58.php
@@ -25,7 +25,7 @@ class base58 {
    * @return   array
    *
    */
-  public function hex_to_bin($hex) {
+  private function hex_to_bin($hex) {
     if (gettype($hex) != 'string') {
       throw new Exception('base58->hex_to_bin(): Invalid input type (must be a string)');
     }
@@ -48,7 +48,7 @@ class base58 {
    * @return   string
    *
    */
-  public function bin_to_hex($bin) {
+  private function bin_to_hex($bin) {
     if (gettype($bin) != 'array') {
       throw new Exception('base58->bin_to_hex(): Invalid input type (must be an array)');
     }
@@ -68,7 +68,7 @@ class base58 {
    * @return   array
    *
    */
-  public function str_to_bin($str) {
+  private function str_to_bin($str) {
     if (gettype($str) != 'string') {
       throw new Exception('base58->str_to_bin(): Invalid input type (must be a string)');
     }
@@ -88,7 +88,7 @@ class base58 {
    * @return   string
    *
    */
-  public function bin_to_str($bin) {
+  private function bin_to_str($bin) {
     if (gettype($bin) != 'array') {
       throw new Exception('base58->bin_to_str(): Invalid input type (must be an array)');
     }
@@ -108,7 +108,7 @@ class base58 {
    * @return   number
    *
    */
-  public function uint8_be_to_64($data) {
+  private function uint8_be_to_64($data) {
     if (gettype($data) != 'array') {
       throw new Exception ('base58->uint8_be_to_64(): Invalid input type (must be an array)');
     }
@@ -148,7 +148,7 @@ class base58 {
    * @return   array
    *
    */
-  public function uint64_to_8_be($num, $size) {
+  private function uint64_to_8_be($num, $size) {
     if (gettype($num) != ('integer' || 'double')) {
       throw new Exception ('base58->uint64_to_8_be(): Invalid input type ($num must be a number)');
     }
@@ -177,7 +177,7 @@ class base58 {
    * @return   array
    *
    */
-  public function encode_block($data, $buf, $index) {
+  private function encode_block($data, $buf, $index) {
     if (gettype($data) != 'array') {
       throw new Exception('base58->encode_block(): Invalid input type ($data must be an array)');
     }
@@ -250,7 +250,7 @@ class base58 {
    * @return   array
    *
    */
-  public function decode_block($data, $buf, $index) {
+  private function decode_block($data, $buf, $index) {
     if (gettype($data) != 'array') {
       throw new Exception('base58->decode_block(): Invalid input type ($data must be an array)');
     }


### PR DESCRIPTION
Helper functions like `str_to_bin()` and `uint64_to_8_be()` probably won't (or shouldn't) be used by code consuming this codec in general.  This pull request makes them privately-scoped and removes their documentation from README.me.